### PR TITLE
Fix expression_delete prototype in expressions.h

### DIFF
--- a/832a/expressions.h
+++ b/832a/expressions.h
@@ -34,7 +34,7 @@ struct expression
 
 
 struct expression *expression_new();
-void expression_delete();
+void expression_delete(struct expression *expr);
 
 struct expression *expression_parse(const char *str);
 int expression_evaluate(const struct expression *expr,const struct equate *equates);


### PR DESCRIPTION
`expression_delete` function prototype does not match implementation:
```
# grep expression_delete -R .
...
./832a/expressions.h:void expression_delete();
./832a/expressions.c:void expression_delete(struct expression *expr)
```